### PR TITLE
Fix: Deep nested singular resource

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -209,7 +209,7 @@ class Repoint {
       const idAttribute = options.idAttribute || 'id'
 
       if (nestedEndpoint !== undefined && nestedEndpoint !== null) {
-        const reversedNestedNamespacedIdAttributes = nestedNamespacedIdAttributes.slice().reverse()
+        const reversedNestedNamespacedIdAttributes = [...nestedNamespacedIdAttributes].reverse()
 
         urls = {
           collection: `${nestedEndpoint.collectionUrl}/:${reversedNestedNamespacedIdAttributes[0]}/${namespacedName}`,
@@ -259,9 +259,11 @@ class Repoint {
     }
 
     if (nestedEndpoint !== undefined && nestedEndpoint !== null) {
+      const reversedNestedNamespacedIdAttributes = [...nestedNamespacedIdAttributes].reverse()
+
       urls = {
         collection: null,
-        member:     `${nestedEndpoint.collectionUrl}/:${nestedNamespacedIdAttributes[0]}/${namespacedName}`
+        member:     `${nestedEndpoint.collectionUrl}/:${reversedNestedNamespacedIdAttributes[0]}/${namespacedName}`
       }
     } else {
       urls = {

--- a/test/meta.js
+++ b/test/meta.js
@@ -99,6 +99,20 @@ test('deeply nested endpoints with idAttribute', t => {
   t.end()
 })
 
+test('deeply nested endpoints for singular resource', t => {
+  const loans = repoint.generate("loans")
+  const negotiations = repoint.generate("negotiations", { nestUnder: loans })
+  const offers = repoint.generate("offers", { nestUnder: negotiations, singular: true })
+
+  t.equal(offers.name, 'offers', 'name property == "offers"')
+  t.equal(offers.collectionUrl, null, 'no collectionUrl')
+  t.equal(offers.memberUrl, '/loans/:loanId/negotiations/:negotiationId/offers', 'memberUrl == "loans/:loanId/negotiations/:negotiationId/offers"')
+  t.deepEqual(offers.idAttributes, ['id', 'id'], 'idAttributes property == [id, id]')
+  t.deepEqual(offers.namespacedIdAttributes, ['loanId', 'negotiationId'], 'namespacedIdAttributes property == [loanId, negotiationId, offerId]')
+
+  t.end()
+})
+
 test('nonRestful methods', t => {
   const users = repoint.generate('users', {}, [{method: 'post', name: 'login', on: 'collection'}])
 


### PR DESCRIPTION
Hi,

### Steps to reproduce
Here is our resources:
```
const users = repoint.generate('users')
const posts = repoint.generate('posts', { nestUnder: users })
const active = repoint.generate('active', { singular: true, nestUnder: posts })
```
### Expected behavior
In such case `memberUrl`will look like that:
`/users/:userId/posts/:postId/active`

### Actual behavior
`/users/:userId/posts/:userId/active`

### Note:
From source code I find out that you have simular issue that you fix in the next commit:
https://github.com/tokenvolt/repoint/commit/1eae7dea68559cfa68aa1d304a88fd766cf7a2a2
But in that commit you fixed only collectional Urls, not singular.

Thanks.